### PR TITLE
general: Add build-system hooks to build analyzer from source

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required (VERSION 3.13)
+
+project(I3CAnalyzer)
+
+add_definitions( -DLOGIC2 )
+
+# enable generation of compile_commands.json, helpful for IDEs to locate include files.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# custom CMake Modules are located in the cmake directory.
+set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+
+include(ExternalAnalyzerSDK)
+
+set(SOURCES 
+	src/I3CAnalyzer.cpp
+	src/I3CAnalyzer.h
+	src/I3CAnalyzerResults.cpp
+	src/I3CAnalyzerResults.h
+	src/I3CAnalyzerSettings.cpp
+	src/I3CAnalyzerSettings.h
+	src/I3CSimulationDataGenerator.cpp
+	src/I3CSimulationDataGenerator.h
+)
+
+add_analyzer_plugin(${PROJECT_NAME} SOURCES ${SOURCES})

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Feel free to share your extensions/modifications. PULL-requests are welcome!
 - Step #4: Select in the section "Custom Low Level Analyzers" the directory where the i3c_analyzer.dll file is located.
 - Step #5: Restart Logic2 software.
 
+# Build from source
+
+Although the binaries are contained in the repository, if conversely, you want to build them yourself, the build system hooks are in place for you to do so. Please refer to [Saleae's guide](https://github.com/saleae/SampleAnalyzer#building-your-analyzer) for details on how to build it.
+
 # How to use
 
 After installation the analyzer can be used like any other decoder. Just click on Analyzer, then the + button and select the I3C decoder.

--- a/cmake/ExternalAnalyzerSDK.cmake
+++ b/cmake/ExternalAnalyzerSDK.cmake
@@ -1,0 +1,57 @@
+include(FetchContent)
+
+# Use the C++11 standard
+set(CMAKE_CXX_STANDARD 11)
+
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
+
+if (NOT CMAKE_RUNTIME_OUTPUT_DIRECTORY OR NOT CMAKE_LIBRARY_OUTPUT_DIRECTORY)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin/)
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin/)
+endif()
+
+# Fetch the Analyzer SDK if the target does not already exist.
+if(NOT TARGET Saleae::AnalyzerSDK)
+    FetchContent_Declare(
+        analyzersdk
+        GIT_REPOSITORY https://github.com/saleae/AnalyzerSDK.git
+        GIT_TAG        master
+        GIT_SHALLOW    True
+        GIT_PROGRESS   True
+    )
+
+    FetchContent_GetProperties(analyzersdk)
+
+    if(NOT analyzersdk_POPULATED)
+        FetchContent_MakeAvailable(analyzersdk)
+        include(${analyzersdk_SOURCE_DIR}/AnalyzerSDKConfig.cmake)
+
+        if(APPLE OR WIN32)
+            get_target_property(analyzersdk_lib_location Saleae::AnalyzerSDK IMPORTED_LOCATION)
+            if(CMAKE_LIBRARY_OUTPUT_DIRECTORY)
+                file(COPY ${analyzersdk_lib_location} DESTINATION ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+            else()
+                message(WARNING "Please define CMAKE_RUNTIME_OUTPUT_DIRECTORY and CMAKE_LIBRARY_OUTPUT_DIRECTORY if you want unit tests to locate ${analyzersdk_lib_location}")
+            endif()
+        endif()
+
+    endif()
+endif()
+
+function(add_analyzer_plugin TARGET)
+    set(options )
+    set(single_value_args )
+    set(multi_value_args SOURCES)
+    cmake_parse_arguments( _p "${options}" "${single_value_args}" "${multi_value_args}" ${ARGN} )
+
+
+    add_library(${TARGET} MODULE ${_p_SOURCES})
+    target_link_libraries(${TARGET} PRIVATE Saleae::AnalyzerSDK)
+
+    set(ANALYZER_DESTINATION "Analyzers")
+    install(TARGETS ${TARGET} RUNTIME DESTINATION ${ANALYZER_DESTINATION}
+                              LIBRARY DESTINATION ${ANALYZER_DESTINATION})
+
+    set_target_properties(${TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${ANALYZER_DESTINATION}
+                                               LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${ANALYZER_DESTINATION})
+endfunction()


### PR DESCRIPTION
This patch includes the CMake build system hooks as well as a note in the readme guiding users to build the analyzer themselves if they desire to.